### PR TITLE
Implementation docker for local deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,49 @@
+# Environment config
+.env*
+
+# Runtime
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Logs
+logs
+*.log
+npm-debug.log*
+CHANGELOG.md
+
+# Mac
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Cache
+.yarn-cache
+.npm
+.eslintcache
+.changelog
+
+# Node
+node_modules
+
+# Reports
+coverage
+reports
+
+# Git config
+.git
+.github
+.gitignore
+
+#Editor Config
+.editorconfig
+
+#Docker config
+Dockerfile*
+docker-compose.yml
+.dockerignore
+
+#Other
+*.md
+LICENSE

--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,7 @@
-MONGODB_URL=mongodb://localhost
+MONGODB_URL=mongodb://localhost:27017
+MONGODB_PORT=27017
 MONGODB_DBNAME=api-fantoir
 TERRITOIRES=
 FANTOIR_PATH=https://adresse.data.gouv.fr/data/fantoir/latest
+PORT=5000
+FORCE_LOAD_FANTOIR_DATA=false

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,12 @@
+# using an optimized node image
+FROM node:16.19.0-alpine
+
+# optimzing caching for yarn install
+WORKDIR /app
+COPY package.json yarn.lock .
+RUN yarn install
+
+# copying the root folder into the workdir taking into account the .dockerignore file
+COPY . .
+
+CMD ["sh", "start.dev.sh"]

--- a/README.md
+++ b/README.md
@@ -1,43 +1,83 @@
 # api-fantoir
 API pour naviguer dans FANTOIR
 
-## Prérequis
+## Utilisation sans Docker
+
+### Prérequis 
 
 - Node.js version 16.13.0 ou supérieure
 - MongoDB version 4.0 ou supérieure
 - yarn
 
-## Installation des dépendances
+### Installation des dépendances
 
 ```bash
 yarn
 ```
 
-## Configuration
+### Chargement des données
+
+```bash
+yarn load-data
+```
+
+### Démarrer le serveur
+
+```bash
+yarn start
+```
+
+## Utilisation avec Docker
+
+### Prérequis 
+
+- Docker version 20.0.0
+- Docker Compose version 2.0.0
+
+### Démarrer l'environnement de developpement
+
+```bash
+docker-compose up --build -d
+```
+
+### Chargement des données
+
+Pour charger les données, il y a deux possibilités : 
+
+1. Chargement à la demande
+
+Dans le client du conteneur de l'api, entrer la commande : 
+
+```bash
+yarn load-data
+```
+
+2. Chargement à chaque lancement du conteneur de l'api
+
+Dans le fichier start.dev.sh, ajouter (ou décommenter la ligne concernée) la commande : 
+
+```bash
+yarn load-data
+```
+
+Attention, le chargement des données peut prendre du temps et il est donc préférable d'utiliser le chargement "à la demande" à la première initialisation des conteneurs. Comme les données sont persistantes (volume 'db'), les données n'auront pas à être chargées à chaque fois.
+
+## Configuration (avec et sans Docker)
 
 Ce dépôt fonctionne avec une configuration par défaut. Il est néanmoins possible de modifier la configuration en changeant les variables d’environnements.
 
 Le fichier `.env.sample` est présent à des fins d’exemple pour créer un fichier `.env`.
 Toutes les variables sont optionnelles.
 
-| Nom de la variable | Description | Valeur par défaut |
-| --- | --- | --- |
-| `MONGODB_URL` | Chemin de connexion à la base MongoDB | `mongodb://localhost` |
-| `MONGODB_DBNAME` | Nom de la base de données MongoDB | `api-fantoir` |
-| `TERRITOIRES` | Liste séparée par des virgules des territoires à prendre en compte (communes ou départements) | (vide) |
-| `FANTOIR_PATH` | Chemin d’accès au fichier FANTOIR à importer. Peut-être une URL ou un chemin local | `https://adresse.data.gouv.fr/data/fantoir/latest` |
-
-## Chargement des données
-
-```bash
-yarn load-data
-```
-
-## Démarrer le serveur
-
-```bash
-yarn start
-```
+| Nom de la variable | Description | Valeur par défaut | Commentaire |
+| --- | --- | --- | --- |
+| `MONGODB_URL` | Chemin de connexion à la base MongoDB | `mongodb://localhost` | Cette variable n'est pas utilisée pour le deploiement Docker en local car elle est surchargée dans le docker-compose |
+| `MONGODB_PORT` | Port du conteneur Docker MongoDB |  | Cette variable est seulement utilisée pour le déploiement Docker en local |
+| `MONGODB_DBNAME` | Nom de la base de données MongoDB | `api-fantoir` | |
+| `TERRITOIRES` | Liste séparée par des virgules des territoires à prendre en compte (communes ou départements) | | |
+| `FANTOIR_PATH` | Chemin d’accès au fichier FANTOIR à importer. Peut-être une URL ou un chemin local | `https://adresse.data.gouv.fr/data/fantoir/latest` | |
+| `PORT` | Port d'écoute de l'API | `5000` | En deploiement sans Docker, la variable surcharge le port d'écoute de l'API. En deploiement avec Docker, la variable surcharge le port externe du conteneur (qui sera mappé au port interne '5000' du conteneur) |
+| `FORCE_LOAD_FANTOIR_DATA` | Variable permettant d'importer les données FANTOIR dans le conteneur Docker MongoDB | | Cette variable est seulement utilisée pour le déploiement Docker en local |
 
 ## API
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  db:
+    # Version of mongoDB currently in production
+    image: mongo:4.2.23
+    ports:
+      - "${MONGODB_PORT:-27017}:27017"
+    volumes:
+      - db:/data/db
+  api:
+    build: 
+      dockerfile: 'Dockerfile.dev'
+    depends_on:
+      - db
+    environment:
+      - MONGODB_URL=mongodb://db
+      - MONGODB_DBNAME=${MONGODB_DBNAME}
+      - TERRITOIRES=${TERRITOIRES}
+      - FANTOIR_PATH=${FANTOIR_PATH}
+      - FORCE_LOAD_FANTOIR_DATA=${FORCE_LOAD_FANTOIR_DATA}
+    ports:
+      - "${PORT:-5000}:5000"
+
+volumes:
+  db:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "type": "module",
   "scripts": {
     "lint": "xo",
-    "load-data": "node load-data"
+    "load-data": "node load-data",
+    "start": "node server"
   },
   "dependencies": {
     "@etalab/fantoir-parser": "^0.5.0",

--- a/start.dev.sh
+++ b/start.dev.sh
@@ -1,0 +1,8 @@
+echo "DOCKER_LOAD_FANTOIR_DATA : $FORCE_LOAD_FANTOIR_DATA"
+
+if [[ "$FORCE_LOAD_FANTOIR_DATA" = "true" ]]; then
+  echo "loading fantoir data into DB..."
+  npm run load-data
+fi
+
+npm run start


### PR DESCRIPTION
This pull request aims to add the docker implementation for local dev deployment

The local deploy uses docker and docker-compose

docker-compose up --build -d

the --build tag aims to build the image, defined in the Dockerfile.dev, before running the service.
the -d tag makes the run in a detached way = run in the background