### PR TITLE
Added mongo port to url connection configuration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,4 @@
-MONGODB_URL=mongodb://localhost:27017
+MONGODB_HOST=localhost
 MONGODB_PORT=27017
 MONGODB_DBNAME=api-fantoir
 TERRITOIRES=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,8 @@ services:
     depends_on:
       - db
     environment:
-      - MONGODB_URL=mongodb://db
+      - MONGODB_HOST=db
+      - MONGODB_PORT=27017
       - MONGODB_DBNAME=${MONGODB_DBNAME}
       - TERRITOIRES=${TERRITOIRES}
       - FANTOIR_PATH=${FANTOIR_PATH}

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -1,7 +1,10 @@
 import {MongoClient, ObjectId} from 'mongodb'
 
-const MONGODB_URL = process.env.MONGODB_URL || 'mongodb://localhost'
+const MONGODB_HOST = process.env.MONGODB_HOST || 'localhost'
+const MONGODB_PORT = process.env.MONGODB_PORT || '27017'
 const MONGODB_DBNAME = process.env.MONGODB_DBNAME || 'api-fantoir'
+
+const MONGODB_URL = `mongodb://${MONGODB_HOST}:${MONGODB_PORT}`
 
 class Mongo {
   async connect(connectionString) {


### PR DESCRIPTION
# Context

In order to make the mongo db connection fully configurable, we need to add the mongo connection port as an env variable.

# Enhancement

- MONGODB_URL env variable split into two env variables : `MONGODB_HOST` & `MONGODB_PORT`